### PR TITLE
Mac shortcut fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Our OP lecturer uses wandbox to show coding examples. Although, it's really hard
 
 - Open Wandbox
 - Run Your code
-- Press Ctrl + Y (Mac: Command + Y)
+- Press Ctrl + Y (Mac: Fn + Y)
 - Enjoy simple and light color scheme of the console
 
 Or
@@ -22,6 +22,12 @@ Or
 ## BIG THANKS TO [Mindaugas Kasiulis](https://github.com/gitguuddd) WHO ENSURED THIS EXTENSION TO WORK AS SMOOTH AS SILK :heart:
 
 ## Changelog
+
+### [v0.2.1](https://github.com/zygisau/WandBox-helper/releases/tag/v0.2.1) - (2019-05-06)  
+
+**Edited**
+
+- Due to issues with already reserved shortcuts, the shortcut for Mac systems was changed from "Command+Y" to "Fn+Y"
 
 ### [v0.2](https://github.com/zygisau/WandBox-helper/releases/tag/v0.2) - (2019-05-01)  
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or
 
 ## Changelog
 
-### [v0.2.1](https://github.com/zygisau/WandBox-helper/releases/tag/v0.2.1) - (2019-05-06)  
+### [v0.2.1](https://github.com/gitguuddd/WandBox-helper/releases/tag/v0.2.1) - (2019-05-06)  
 
 **Edited**
 

--- a/manifest.json
+++ b/manifest.json
@@ -23,14 +23,14 @@
         "description":"Change colors",
         "suggested_key": {
           "default": "Ctrl+Y",
-          "mac": "Command+Y"
+          "mac": "Fn+Y"
         }
       },
       "_execute_browser_action": {
         "description":"Change colors",
         "suggested_key": {
           "default": "Ctrl+Y",
-          "mac": "Command+Y"
+          "mac": "Fn+Y"
         }
       }
 


### PR DESCRIPTION
Changed the Mac shortcut from "Command+Y" to "Fn+y" due to former being already reserved for "Use Quick Look to preview the selected files." Requires testing on Mac.